### PR TITLE
Update html-webpack-plugin to 2.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint-config-defaults": "8.0.2",
     "file-loader": "0.8.4",
     "html-loader": "0.3.0",
-    "html-webpack-plugin": "1.6.1",
+    "html-webpack-plugin": "2.24.1",
     "jasmine-core": "2.3.4",
     "karma": "0.13.19",
     "karma-chrome-launcher": "0.2.0",


### PR DESCRIPTION
This fixes `ERROR in Path must be a string. Received undefined`.

```
$ node -v
v7.2.1
```