### PR TITLE
Add jQuery reference to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ var PARAMS_DEFAULT = {
             // https://github.com/angular/angular.js/blob/v1.5.9/src/Angular.js#L1821-L1823
             // http://blog.johnnyreilly.com/2016/05/the-mysterious-case-of-webpack-angular-and-jquery.html
             'window.jQuery': 'jquery',
-            'jQuery: 'jquery'
+            'jQuery': 'jquery'
         }),
         new webpack.optimize.DedupePlugin()
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,8 @@ var PARAMS_DEFAULT = {
         new webpack.ProvidePlugin({
             // https://github.com/angular/angular.js/blob/v1.5.9/src/Angular.js#L1821-L1823
             // http://blog.johnnyreilly.com/2016/05/the-mysterious-case-of-webpack-angular-and-jquery.html
-            'window.jQuery': 'jquery'
+            'window.jQuery': 'jquery',
+            'jQuery: 'jquery'
         }),
         new webpack.optimize.DedupePlugin()
     ],


### PR DESCRIPTION
At its current state, Bootstrap transition.js references 'jQuery' which causes the following error using webpack build:
```
Uncaught ReferenceError: jQuery is not defined
    at Object.<anonymous> (transition.js:59)
    at __webpack_require__ (bootstrap 595d807…:50)
    at Object.<anonymous> (npm.js:2)
    at __webpack_require__ (bootstrap 595d807…:50)
    at Object.<anonymous> (bootstrap 595d807…:93)
    at __webpack_require__ (bootstrap 595d807…:50)
    at bootstrap 595d807…:93
    at bootstrap 595d807…:93
```
Steps to produce:
- npm install
- npm run build
- npm run server_build
- Open in Chrome